### PR TITLE
DTSPO-6855 - use the new graph api instead of the ad one to delete users

### DIFF
--- a/pipeline-scripts/delete-user.sh
+++ b/pipeline-scripts/delete-user.sh
@@ -7,6 +7,8 @@ delete_user() {
 
   if [[ $branch == "master" ]]; then
     echo "Deleting user ${3} with the mail address of ${2} and object ID of ${1}"
+     # TODO https://github.com/Azure/azure-cli/issues/12946#issuecomment-737196942
+     # az ad user delete --id ${1}
      az rest --method DELETE --uri "https://graph.microsoft.com/v1.0/users/${1}"
   else
     echo "Plan: user ${3}, mail address ${2}, object ID ${1}"

--- a/pipeline-scripts/delete-user.sh
+++ b/pipeline-scripts/delete-user.sh
@@ -7,7 +7,7 @@ delete_user() {
 
   if [[ $branch == "master" ]]; then
     echo "Deleting user ${3} with the mail address of ${2} and object ID of ${1}"
-    az ad user delete --id ${1}
+     az rest --method DELETE --uri "https://graph.microsoft.com/v1.0/users/${1}"
   else
     echo "Plan: user ${3}, mail address ${2}, object ID ${1}"
   fi


### PR DESCRIPTION
### Change description ###
Az cli uses the old graph atm and we cannot add permissions to the legacy api anymore, so changing command to use the new api instead.

Issue for moving to the new api: https://github.com/Azure/azure-cli/issues/12946#issuecomment-737196942

Legacy api greyed out:

<img width="718" alt="Screenshot 2022-03-09 at 15 41 10" src="https://user-images.githubusercontent.com/72858053/157476005-ef2d5aaf-d3a6-497a-877a-89aafc905c7c.png">




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
