### PR TITLE
Run cleanup at 2am

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -1,8 +1,8 @@
 name: guest-user-management
 
 schedules:
-  - cron: "0 6 * * *"
-    displayName: Daily build @ 6am
+  - cron: "0 2 * * *"
+    displayName: Daily build @ 2am
     always: true
     branches:
       include:


### PR DESCRIPTION
devops-azure-ad runs at 4am, so this meant that people had to manually fix in devops-azure-ad
